### PR TITLE
Fix render scheduling and addItem visibility check

### DIFF
--- a/src/virtualist.js
+++ b/src/virtualist.js
@@ -234,7 +234,7 @@ class VirtuaList {
     addItem(index, immediate) {
         if (index < 0 || index > this.totalItems) return;
 
-        const needsRender = this.renderedItems.has(index) || index <= this.lastStart;
+        const needsRender = this.renderedItems.has(index);
         this.totalItems += 1;
 
         let tempHeight = this.defaultItemHeight;

--- a/src/virtualist.js
+++ b/src/virtualist.js
@@ -65,7 +65,7 @@ class VirtuaList {
         }
 
         this.queued = true;
-        this.scrollAnimationFrame = requestAnimationFrame(() => {
+        this.renderingAnimationFrame = requestAnimationFrame(() => {
             this.queued = false;
             this.render(force);
         });
@@ -234,7 +234,7 @@ class VirtuaList {
     addItem(index, immediate) {
         if (index < 0 || index > this.totalItems) return;
 
-        const needsRender = this.renderedItems.has(index);
+        const needsRender = this.renderedItems.has(index) || index <= this.lastStart;
         this.totalItems += 1;
 
         let tempHeight = this.defaultItemHeight;


### PR DESCRIPTION
## Summary
- correctly store animation frame handle used for rendering
- ensure addItem forces render when items are inserted before visible range

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68457867a2e0832489b9df361a746877